### PR TITLE
Potential fix for code scanning alert no. 62: Server-side request forgery

### DIFF
--- a/frontend/src/utils/api/taskApi.ts
+++ b/frontend/src/utils/api/taskApi.ts
@@ -27,6 +27,14 @@ function formatUUID(id: string) {
   if (id.includes("-")) return id; // already valid
   return id.replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, "$1-$2-$3-$4-$5");
 }
+
+// UUID validation (accepts v4 UUIDs with/without hyphens)
+function isValidUUID(id: string) {
+  // Allows UUIDs with or without hyphens, 32 hex or 8-4-4-4-12 form
+  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id)
+      || /^[0-9a-fA-F]{32}$/.test(id);
+}
+
 export const taskApi = {
   getTaskStatusByProject: async ({
     projectId,
@@ -944,6 +952,9 @@ export const taskApi = {
   },
 
   assignTaskAssignees: async (taskId: string, assigneeIds: string[]) => {
+    if (!isValidUUID(taskId)) {
+      throw new Error("Invalid taskId provided.");
+    }
     try {
       const response = await api.patch(`/tasks/${taskId}/assignees`, {
         assigneeIds,


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/62](https://github.com/Taskosaur/Taskosaur/security/code-scanning/62)

The optimal fix is to validate the "taskId" parameter before interpolating it into the outgoing request's URL. Since the codebase appears to expect UUIDs for IDs, add a UUID validation check before the call to `api.patch` in `assignTaskAssignees`. If the ID fails validation, throw an Error and do not proceed with the request.

- Only edit code in the shown snippets—here, that's in `frontend/src/utils/api/taskApi.ts`.
- Implement a robust UUID validation function (v4 UUIDs are standard).
- Before making the request in `assignTaskAssignees`, validate `taskId` using this function.
- If invalid, throw an error (do not proceed with the API call).
- Import or define the validation utility at file scope if not present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
