### PR TITLE
Potential fix for code scanning alert no. 61: Server-side request forgery

### DIFF
--- a/frontend/src/utils/api/taskApi.ts
+++ b/frontend/src/utils/api/taskApi.ts
@@ -22,6 +22,10 @@ import {
 } from "@/types";
 
 // Task interfaces
+function isValidUUID(id: string) {
+  return typeof id === "string" && /^[0-9a-fA-F-]{36}$/.test(id);
+}
+
 function formatUUID(id: string) {
   if (!id) return id;
   if (id.includes("-")) return id; // already valid
@@ -768,6 +772,9 @@ export const taskApi = {
 
   removeLabelFromTask: async (taskId: string, labelId: string): Promise<void> => {
     try {
+      if (!isValidUUID(taskId) || !isValidUUID(labelId)) {
+        throw new Error("Invalid taskId or labelId");
+      }
       await api.delete(`/task-labels/${taskId}/${labelId}`);
     } catch (error) {
       console.error("Remove label from task error:", error);


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/61](https://github.com/Taskosaur/Taskosaur/security/code-scanning/61)

We should ensure that `taskId` and `labelId` used in API routes are strictly validated before used to construct URLs.  
The best way is to whitelist the allowed format: typically, both IDs are UUID v4 strings, so we can use a regex validator that matches `/^[0-9a-fA-F-]{36}$/` (or stricter if required) and return an error or abort the API call if validation fails.  
- The changes should be made in `frontend/src/utils/api/taskApi.ts`, replacing the vulnerable line (and similar ones that use unvalidated user input).
- Add a helper function for validating an ID format (UUID), and use it before constructing the URL for delete/remove label calls.
- Optionally, log or throw a controlled error if inputs are not valid.
- Only changes within the shown code are permitted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
