### PR TITLE
Potential fix for code scanning alert no. 58: Server-side request forgery

### DIFF
--- a/frontend/src/utils/api/taskApi.ts
+++ b/frontend/src/utils/api/taskApi.ts
@@ -588,6 +588,9 @@ export const taskApi = {
 
   // Task Attachment operations
   uploadAttachment: async (taskId: string, file: File): Promise<TaskAttachment> => {
+    if (!isValidUUID(taskId)) {
+      throw new Error("Invalid taskId format. Expected a UUID.");
+    }
     try {
       const formData = new FormData();
       formData.append("file", file);


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/58](https://github.com/Taskosaur/Taskosaur/security/code-scanning/58)

To address this vulnerability, you should validate the `taskId` parameter before using it in the HTTP request. Fortunately, the file already defines a helper function `isValidUUID`; we should use this to confirm that `taskId` matches the expected format (UUID). If `taskId` fails validation, throw an error before sending the request. This change affects the function `uploadAttachment` in `frontend/src/utils/api/taskApi.ts` (beginning line 590): add a runtime check using `isValidUUID(taskId)` before the API call, and throw an error if validation fails.

No new imports are needed, as `isValidUUID` is already present in the same file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
