### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -6,6 +6,8 @@ on:
       - docker/build/development
       - docker/build/latest
 
+permissions:
+  contents: read
 env:
   DOCKER_IMAGE: taskosaur/taskosaur
   PLATFORMS: linux/amd64,linux/arm64


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/1](https://github.com/Taskosaur/Taskosaur/security/code-scanning/1)

To fix the problem, add an explicit `permissions` key at the root of the workflow (before or after the `env:` block and before `jobs:`). Set it to the minimum required, which for most Docker build/push workflows is `contents: read`. If in the future a step requires additional write permission (for e.g., PRs, packages, etc.), permissions can be added specifically as needed at the job or step level. This change is done to `.github/workflows/docker-build-push.yml`, inserting:

```yaml
permissions:
  contents: read
```

after the `name:` (line 1) and before `env:` (line 9), or after the `on:` block if preferred (after line 8, before line 9).

No new methods, imports, or other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
