### PR TITLE
Potential fix for code scanning alert no. 8: Client-side URL redirect

### DIFF
--- a/frontend/src/pages/[workspaceSlug]/projects/index.tsx
+++ b/frontend/src/pages/[workspaceSlug]/projects/index.tsx
@@ -1,6 +1,9 @@
 import { useRouter } from "next/router";
 import ProjectsContent from "@/components/projects/ProjectsContent";
 
+// Only allow safe slugs - letters, numbers, dashes, underscores
+const isSafeSlug = (slug?: string) => typeof slug === "string" && /^[a-zA-Z0-9_-]+$/.test(slug);
+
 export default function WorkspaceProjectsPage() {
   const router = useRouter();
   const { workspaceSlug } = router.query;
@@ -15,7 +18,11 @@ export default function WorkspaceProjectsPage() {
       emptyStateTitle="No projects found"
       emptyStateDescription="Create your first project to get started with organizing your tasks and collaborating with your team."
       enablePagination={false}
-      generateProjectLink={(project, workspaceSlug) => `/${workspaceSlug}/${project.slug}`}
+      generateProjectLink={(project, ws) =>
+        isSafeSlug(ws) && isSafeSlug(project?.slug)
+          ? `/${ws}/${project.slug}`
+          : undefined
+      }
     />
   );
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/8](https://github.com/Taskosaur/Taskosaur/security/code-scanning/8)

The best way to fix this problem is to sanitize and validate user-controlled path segments (`workspaceSlug` and `project.slug`) before constructing URLs. Only allow internal navigation to safe, expected slugs by checking that the values meet a whitelist pattern (e.g., /^[a-zA-Z0-9_-]+$/). This can be performed at the point where the `generateProjectLink` function is created or before passing the value as an href.  

We should:  
- Create a helper validation function in `ProjectsContent.tsx` (where `generateProjectLink` is generated inline) to check slug validity.
- Update the inline `generateProjectLink` in `frontend/src/pages/[workspaceSlug]/projects/index.tsx` so that it only constructs links if both `workspaceSlug` and `project.slug` pass the safe pattern.
- On validation failure, consider returning `"#"` or `undefined` (preventing navigation), or omit the link.
- No changes are needed in `EntityCard.tsx`, because with the above, `href` will not contain unsafe values.

We only edit files we've been shown:  
- Add the helper/validation function in `frontend/src/pages/[workspaceSlug]/projects/index.tsx` (since `generateProjectLink` is defined inline there).
- Use that validated function to protect the composition of slugs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
