### PR TITLE
Potential fix for code scanning alert no. 9: Client-side URL redirect

### DIFF
--- a/frontend/src/components/gantt/TaskInfoPanel.tsx
+++ b/frontend/src/components/gantt/TaskInfoPanel.tsx
@@ -11,6 +11,11 @@ interface TaskInfoPanelProps {
   onFocus: (taskId: string) => void;
 }
 
+13a: // Utility to validate slug strings: alphanumeric and dash only
+13b: function sanitizeSlug(slug: string | undefined): string | undefined {
+13c:   return slug && /^[a-zA-Z0-9\-]+$/.test(slug) ? slug : undefined;
+13d: }
+
 // Task Info Panel Component
 export const TaskInfoPanel: React.FC<TaskInfoPanelProps> = ({
   task,
@@ -20,8 +25,6 @@ export const TaskInfoPanel: React.FC<TaskInfoPanelProps> = ({
   projectSlug,
   onFocus,
 }) => {
-  return (
-    <div
       className={`${
         isCompact ? "w-48" : "w-80"
       } px-4 border-r border-[var(--border)] shrink-0 sticky left-0 z-[999999] py-2 bg-[var(--card)] `}
@@ -31,10 +34,10 @@ export const TaskInfoPanel: React.FC<TaskInfoPanelProps> = ({
         <div className="flex items-center justify-between gap-2">
           <Link
             href={
-              workspaceSlug && projectSlug
-                ? `/${workspaceSlug}/${projectSlug}/tasks/${task.id}`
-                : workspaceSlug
-                  ? `/${workspaceSlug}/tasks/${task.id}`
+              safeWorkspaceSlug && safeProjectSlug
+                ? `/${safeWorkspaceSlug}/${safeProjectSlug}/tasks/${task.id}`
+                : safeWorkspaceSlug
+                  ? `/${safeWorkspaceSlug}/tasks/${task.id}`
                   : `/tasks/${task.id}`
             }
             className={`font-medium text-[var(--foreground)] hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-200 flex-1 min-w-0 focus:outline-none focus:ring-2 focus:ring-[var(--ring)] focus:ring-offset-2 rounded-sm ${

--- a/frontend/src/components/tasks/views/TaskGanttView.tsx
+++ b/frontend/src/components/tasks/views/TaskGanttView.tsx
@@ -11,6 +11,11 @@ import TaskTableSkeleton from "@/components/skeletons/TaskTableSkeleton";
 
 const MINIMUM_ROWS = 9;
 
+13a: // Utility to validate slug strings: alphanumeric and dash only
+13b: function sanitizeSlug(slug: string | undefined): string | undefined {
+13c:   return slug && /^[a-zA-Z0-9\-]+$/.test(slug) ? slug : undefined;
+13d: }
+
 export default function TaskGanttView({
   tasks,
   workspaceSlug,
@@ -19,7 +24,6 @@ export default function TaskGanttView({
   onViewModeChange,
 }: TaskGanttViewProps) {
   const router = useRouter();
-  const safeTasks = useMemo(() => (Array.isArray(tasks) ? tasks : []), [tasks]);
 
   const [ganttTasks, setGanttTasks] = useState<Task[]>([]);
   const [timeRange, setTimeRange] = useState<TimeRange>({
@@ -160,10 +164,10 @@ export default function TaskGanttView({
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
         const href =
-          workspaceSlug && projectSlug
-            ? `/${workspaceSlug}/${projectSlug}/tasks/${task.id}`
-            : workspaceSlug
-              ? `/${workspaceSlug}/tasks/${task.id}`
+          safeWorkspaceSlug && safeProjectSlug
+            ? `/${safeWorkspaceSlug}/${safeProjectSlug}/tasks/${task.id}`
+            : safeWorkspaceSlug
+              ? `/${safeWorkspaceSlug}/tasks/${task.id}`
               : `/tasks/${task.id}`;
         router.push(href);
       }
@@ -345,8 +349,8 @@ export default function TaskGanttView({
                       task={task}
                       isCompact={isCompact}
                       isOverdue={isOverdue}
-                      workspaceSlug={workspaceSlug}
-                      projectSlug={projectSlug}
+                      workspaceSlug={safeWorkspaceSlug}
+                      projectSlug={safeProjectSlug}
                       onFocus={setFocusedTask}
                     />
 
@@ -358,8 +362,8 @@ export default function TaskGanttView({
                       isCompact={isCompact}
                       isHovered={isHovered}
                       isFocused={isFocused}
-                      workspaceSlug={workspaceSlug}
-                      projectSlug={projectSlug}
+                      workspaceSlug={safeWorkspaceSlug}
+                      projectSlug={safeProjectSlug}
                       onHover={setHoveredTask}
                       onFocus={setFocusedTask}
                       onKeyDown={handleKeyDown}


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/9](https://github.com/Taskosaur/Taskosaur/security/code-scanning/9)

To fix this vulnerability, all usage of `workspaceSlug` and `projectSlug` inside the path construction logic must ensure these values are not tainted with unsafe characters that could facilitate open redirects or path traversal. The best practice is to validate these values against a whitelist or a safe pattern (e.g., /^[a-zA-Z0-9\-]+$/), allowing only slugs consisting of alphanumerics and hyphens. If validation fails, fallback to a safe default value or prevent navigation.

This fix can be accomplished by:

- Adding a utility function (in the file or at the top) to validate a slug string.
- Using this validator before interpolating the slug into a redirect path: filter or sanitize `workspaceSlug` and `projectSlug`, and use only if valid.
- In both the `<Link>` usage in TaskInfoPanel and in the redirect construction (`router.push`) in TaskGanttView, replace direct use with validated/sanitized slugs. If invalid, construct the path ignoring those components, or navigate to a safe fallback path.

The changes should be limited to the shown regions (i.e. only in the two vulnerable files at the points where slugs are interpolated into URLs) and require adding a validator utility to both files, then replacing path construction to use only validated slugs.

No external library is needed, as basic regular expression validation is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
