### PR TITLE
Potential fix for code scanning alert no. 50: Server-side request forgery

### DIFF
--- a/frontend/src/utils/api/taskApi.ts
+++ b/frontend/src/utils/api/taskApi.ts
@@ -26,6 +26,11 @@ function isValidUUID(id: string) {
   return typeof id === "string" && /^[0-9a-fA-F-]{36}$/.test(id);
 }
 
+// Helper to validate slugs (alphanumeric, dash, underscore)
+function isValidSlug(slug: string) {
+  return typeof slug === "string" && /^[a-zA-Z0-9-_]+$/.test(slug);
+}
+
 function formatUUID(id: string) {
   if (!id) return id;
   if (id.includes("-")) return id; // already valid
@@ -305,6 +310,12 @@ export const taskApi = {
     try {
       if (!workspaceSlug || !projectSlug) {
         throw new Error("workspaceSlug and projectSlug are required");
+      }
+      if (!isValidSlug(workspaceSlug)) {
+        throw new Error("Invalid workspaceSlug");
+      }
+      if (!isValidSlug(projectSlug)) {
+        throw new Error("Invalid projectSlug");
       }
 
       const params = new URLSearchParams();


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/50](https://github.com/Taskosaur/Taskosaur/security/code-scanning/50)

To reliably fix the problem, we need to restrict the format and allowed values for `workspaceSlug` and `projectSlug` before incorporating them into the request URL. The most robust approach is to validate these values against a strict regular expression, only allowing expected characters (typically, alphanumerics, underscores, hyphens). Ideally, the values should also be checked for length, and potentially compared against a known list or validated by the backend.

The single best fix here:
- In `getPublicProjectTasks`, enforce strict validation for both `workspaceSlug` and `projectSlug` before assembling the API request URL.
- If either fails validation, throw an error.
- Use a regex like `/^[a-zA-Z0-9-_]+$/` for "slug" patterns (modify as per your legitimate slug rules).
- The validation can be done with a helper function within the same file.
- No external package is needed for basic regex matching.

Edits needed:
- File: `frontend/src/utils/api/taskApi.ts`: add a `isValidSlug` function; check both inputs in `getPublicProjectTasks`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
