### PR TITLE
Potential fix for code scanning alert no. 11: Client-side URL redirect

### DIFF
--- a/frontend/src/components/sprints/SprintCard.tsx
+++ b/frontend/src/components/sprints/SprintCard.tsx
@@ -28,6 +28,11 @@ export const SprintCard = ({
   const { projectSlug, workspaceSlug } = router.query;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
+  // Only allow slugs consisting of alphanumerics, hyphens, and underscores, 1-64 chars
+  const isValidSlug = (slug: unknown): slug is string => {
+    return typeof slug === "string" && /^[a-zA-Z0-9_-]{1,64}$/.test(slug);
+  };
+
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     return date.toLocaleDateString("en-US", {
@@ -58,6 +63,10 @@ export const SprintCard = ({
   const handleCardClick = (e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
     if (target.closest(".dropdown-menu-trigger") || target.closest(".dropdown-menu-content")) {
+      return;
+    }
+    if (!isValidSlug(workspaceSlug) || !isValidSlug(projectSlug)) {
+      // Optionally display an error or just abort navigation
       return;
     }
     router.push(`/${workspaceSlug}/${projectSlug}/sprints/${sprint.id}`);


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/11](https://github.com/Taskosaur/Taskosaur/security/code-scanning/11)

To address the issue, all user-provided values that are interpolated into client-side navigation URLs (such as `workspaceSlug` and `projectSlug` from `router.query`) should be validated before use. The optimal fix is to sanitize or validate these slugs so only allowed strings are used in the navigation URL, preventing malicious path injection or redirect manipulation.

Specifically, before constructing the route `/[workspaceSlug]/[projectSlug]/sprints/[sprint.id]`, we can:
- Ensure that `workspaceSlug` and `projectSlug` conform to an expected pattern (e.g., allow only alphanumeric characters, dashes, and underscores with a reasonable length).
- If any value fails validation, block the navigation or optionally display an error.

This can be done by creating a helper function for basic slug validation (using a regex), and then, in `handleCardClick`, validate `workspaceSlug` and `projectSlug` before using them in the path.  
If the slugs are not valid, navigation is aborted.  
The changes should all be made within `frontend/src/components/sprints/SprintCard.tsx`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
