### PR TITLE
Potential fix for code scanning alert no. 39: Type confusion through parameter tampering

### DIFF
--- a/backend/src/modules/tasks/tasks.controller.ts
+++ b/backend/src/modules/tasks/tasks.controller.ts
@@ -405,8 +405,11 @@ export class TasksController {
   ) {
     const user = getAuthUser(req);
 
-    // Validate file count
-    if (files && files.length > 10) {
+    // Validate file type and count
+    if (!Array.isArray(files)) {
+      throw new BadRequestException('Files must be an array of uploaded file objects');
+    }
+    if (files.length > 10) {
       throw new BadRequestException('Maximum 10 files allowed');
     }
     return this.tasksService.createWithAttachments(createTaskDto, user.id, files);


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/39](https://github.com/Taskosaur/Taskosaur/security/code-scanning/39)

To fix the problem, add an explicit runtime type check before using `files` as an array. Specifically, ensure `files` is not only truthy but is an actual array of objects before reading its `length`, and that each entry is of the expected type. If `files` is not an array, reject the request as invalid. Edit lines within the controller function in `backend/src/modules/tasks/tasks.controller.ts`, specifically within the `creatcreateWithAttachmentse` method. No new imports are needed—TypeScript and Node's type checking and exceptions are sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
