### PR TITLE
Potential fix for code scanning alert no. 6: Insecure randomness

### DIFF
--- a/frontend/src/lib/mcp-server.ts
+++ b/frontend/src/lib/mcp-server.ts
@@ -66,7 +66,11 @@ class MCPServer {
     if (typeof window !== "undefined") {
       let sessionId = sessionStorage.getItem("mcp-session-id");
       if (!sessionId) {
-        sessionId = `session_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+        // Use cryptographically secure random value for suffix
+        const array = new Uint32Array(1);
+        window.crypto.getRandomValues(array);
+        const randomSuffix = array[0].toString(36).substring(0, 9);
+        sessionId = `session_${Date.now()}_${randomSuffix}`;
         sessionStorage.setItem("mcp-session-id", sessionId);
       } else {
       }
@@ -74,7 +78,16 @@ class MCPServer {
     }
 
     // Fallback for server-side rendering
-    return `session_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+    // Fallback for server-side rendering: use insecure randomness, but ideally would use node crypto. Here, using insecure randomness as last resort.
+    let randomSuffix = '';
+    try {
+      // Try Node.js crypto if available
+      const crypto = require('crypto');
+      randomSuffix = crypto.randomBytes(4).toString('hex').substring(0, 9);
+    } catch (e) {
+      randomSuffix = Math.random().toString(36).substring(2, 11);
+    }
+    return `session_${Date.now()}_${randomSuffix}`;
   }
 
   // Update context (e.g., when user navigates to different workspace/project)


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/6](https://github.com/Taskosaur/Taskosaur/security/code-scanning/6)

To fix the problem, replace all usages of `Math.random()` for generating the random session suffix in `getOrCreateSessionId()` with a cryptographically secure random value generator. In browsers, this is `window.crypto.getRandomValues()`; in Node, you would use `require('crypto').randomBytes`, but this code seems designed primarily for browser use due to heavy use of `window` and DOM-related storage. Therefore, switch to `window.crypto.getRandomValues()` for generating the random suffix for sessionId. This requires converting the random bytes to a base36 string to retain current behavior. Update both the client-side and fallback server-side (if relevant) case.

This requires an import or type for using browser crypto, if type errors occur; otherwise, directly replace the random number generation block in frontend/src/lib/mcp-server.ts lines 69 and 77.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
