### PR TITLE
Potential fix for code scanning alert no. 34: Type confusion through parameter tampering

### DIFF
--- a/backend/src/modules/projects/projects.service.ts
+++ b/backend/src/modules/projects/projects.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   ConflictException,
   ForbiddenException,
+  BadRequestException,
 } from '@nestjs/common';
 import { Project, Role } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -233,6 +234,13 @@ export class ProjectsService {
     }
 
     const { status, priority, search, page = 1, pageSize = 10 } = filters || {};
+    // Ensure status and priority are strings if defined (prevent type confusion)
+    if (status !== undefined && typeof status !== 'string') {
+      throw new BadRequestException('Invalid type for parameter "status". Must be a string.');
+    }
+    if (priority !== undefined && typeof priority !== 'string') {
+      throw new BadRequestException('Invalid type for parameter "priority". Must be a string.');
+    }
     const whereClause: any = {
       archive: false,
       OR: [{ members: { some: { userId } } }, { visibility: 'PUBLIC' }],


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/34](https://github.com/Taskosaur/Taskosaur/security/code-scanning/34)

To resolve the issue, we must ensure that the `status` (and `priority`, as it's used the same way) parameters are checked to be of type `string` before any string methods (like `.includes`, `.split`, etc.) are used. If the received value is an array, you should either reject it (e.g., by throwing an error) or sanitize/convert it into a string in a safe way, depending on your application's needs. Since these fields function as filters and the logic expects strings (possibly CSV), it is most appropriate to reject (fail) if the user provides a non-string. This should be done at the start of the `findAll` function. The type check can be achieved with a simple `typeof param !== 'string'` test, similar to the recommended fix in the background information. If the check fails, throw a `BadRequestException` or `ForbiddenException` as fits returning user error input. This should be applied for both `status` and `priority`.

**Files/Regions to change:**  
- Edit `backend/src/modules/projects/projects.service.ts` in the `findAll` method:  
  - After destructuring status/priority from filters (line 235), insert type checks to ensure these parameters are strings if they're defined.
  - Throw `BadRequestException` if the types are not strings.
- Import `BadRequestException` from `@nestjs/common` at the top (currently not imported).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
