### PR TITLE
Potential fix for code scanning alert no. 65: Server-side request forgery

### DIFF
--- a/frontend/src/utils/api/taskApi.ts
+++ b/frontend/src/utils/api/taskApi.ts
@@ -619,15 +619,15 @@ export const taskApi = {
   },
 
   getTaskAttachments: async (taskId: string, isAuth: boolean): Promise<TaskAttachment[]> => {
+    // Validate that taskId is a UUID before using in any endpoint
+    if (!isValidUUID(taskId)) {
+      throw new Error("Invalid taskId format");
+    }
     try {
       let response;
       if (isAuth) {
         response = await api.get<TaskAttachment[]>(`/task-attachments/task/${taskId}`);
       } else {
-        // Validate that taskId is a UUID before using in a public endpoint
-        if (!isValidUUID(taskId)) {
-          throw new Error("Invalid taskId format");
-        }
         response = await api.get<TaskAttachment[]>(`/public/project-tasks/attachments/${taskId}`);
       }
       return response.data;


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/65](https://github.com/Taskosaur/Taskosaur/security/code-scanning/65)

The best way to fix the problem is to validate the `taskId` before it is interpolated into the path of an outgoing API request. There already exists a helper function, `isValidUUID()`, which can validate UUIDs (including the accepted formats for your app). In the code for the `getTaskAttachments` method (`taskApi.getTaskAttachments`), we should enforce this validation for all cases, not just the public/unauthenticated branch. The fix includes:
- Adding a check with `isValidUUID(taskId)` before making the GET request in both branches (authenticated and unauthenticated) of `getTaskAttachments`.
- Throwing a clear error if validation fails (so the route is not called with an invalid path).

This change is localized to `frontend/src/utils/api/taskApi.ts`, in the `getTaskAttachments` method (line 621 onwards). No new dependencies or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
