### PR TITLE
Potential fix for code scanning alert no. 62: Server-side request forgery

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,8 @@
     "recharts": "^2.15.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
-    "zod": "^4.0.14"
+    "zod": "^4.0.14",
+    "validator": "^13.15.23"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/62](https://github.com/Taskosaur/Taskosaur/security/code-scanning/62)

To robustly prevent SSRF, ensure any untrusted identifier (like `taskId`) interpolated in API paths is strictly validated as a UUID using a strong, well-tested validation function. The current regex seems sufficient for v4 UUIDs (with or without hyphens), but to further strengthen the defense:
- Consider centralizing UUID validation and formatting, using a standard UUID library (`validator` or `uuid`) for reliable checks.
- In `assignTaskAssignees`, before making any API request, call the UUID validator and, if valid, format it uniformly (e.g., hyphenated v4). If not valid, throw an error and do not proceed with the request.
- This prevents path-traversal and malicious interleaving with the API path.
- If possible, update error handling to distinguish validation errors early.
- Only edit frontend/src/utils/api/taskApi.ts where the SSRF occurs.

No additional changes needed elsewhere unless you want to replace the custom UUID regex with a library solution.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
