### PR TITLE
Potential fix for code scanning alert no. 38: Type confusion through parameter tampering

### DIFF
--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -690,7 +690,7 @@ export class SearchService {
   }
 
   async getSuggestions(query: string, limit: number = 10): Promise<string[]> {
-    if (query.length < 2) return [];
+    if (typeof query !== 'string' || query.length < 2) return [];
 
     // Get suggestions from task titles
     const taskTitles = await this.prisma.task.findMany({


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/38](https://github.com/Taskosaur/Taskosaur/security/code-scanning/38)

To prevent type confusion, the input parameter (`query`) must be checked at runtime to ensure it is a string before it is processed as such in the `getSuggestions` method. If it is not a string (such as an array), the method should respond as it would to invalid input (e.g., return an empty array or throw an error). This is most cleanly handled in the `getSuggestions` method in `search.service.ts`.

The best way to fix is:  
- At the start of `getSuggestions`, add a runtime type check for `query`.  
- If `typeof query !== 'string'`, either return an empty array or throw a proper error. For consistency with the current logic on "short queries", returning an empty array seems appropriate here—but if you prefer erroring, you can alternatively throw a `BadRequestException` from `@nestjs/common`.
- The same pattern should be applied anywhere else string-based query parameters are used without type validation (but based on the snippets, only this location is immediately relevant).

No imports are needed unless you wish to throw an error (e.g., BadRequestException).

**Files/regions/lines to change:**  
- `backend/src/modules/search/search.service.ts`, in the `getSuggestions` method, add a runtime validation so that the code path proceeds only if `query` is a string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
