### PR TITLE
Potential fix for code scanning alert no. 36: Type confusion through parameter tampering

### DIFF
--- a/backend/src/modules/projects/projects.service.ts
+++ b/backend/src/modules/projects/projects.service.ts
@@ -352,12 +352,12 @@ export class ProjectsService {
     if (workspaceId) {
       whereClause.workspaceId = workspaceId;
     }
-    if (status) {
+    if (status && typeof status === 'string') {
       whereClause.status = status.includes(',')
         ? { in: status.split(',').map((s) => s.trim()) }
         : status;
     }
-    if (priority) {
+    if (priority && typeof priority === 'string') {
       whereClause.priority = priority.includes(',')
         ? { in: priority.split(',').map((p) => p.trim()) }
         : priority;


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/36](https://github.com/Taskosaur/Taskosaur/security/code-scanning/36)

To fix the problem, ensure that `status` (and similarly `priority`) are strictly treated as strings before applying string methods or logic. In general, insert a runtime type guard before using these variables in logic that expects a string. The best pattern is to check `typeof status === 'string'` (or `priority`) before applying string methods, and otherwise ignore, warn, or throw an error. 

The fix should be made in `findByOrganizationId` in `projects.service.ts`, specifically around the block where `status` and `priority` are handled (lines 355–359 and 360–363). If the variable isn't a string, either filter it out, skip it, or explicitly throw a `BadRequestException`. To maintain current functionality, we'll simply ignore/bypass the filter if type is not string.

No new imports are required as the needed exceptions are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
