### PR TITLE
Potential fix for code scanning alert no. 81: Incomplete multi-character sanitization

### DIFF
--- a/frontend/src/components/common/DualModeEditor.tsx
+++ b/frontend/src/components/common/DualModeEditor.tsx
@@ -132,7 +132,7 @@ function markdownToHtml(markdown: string): string {
 function htmlToMarkdown(html: string): string {
   if (!html) return "";
 
-  return html
+  let markdown = html
     // Headers
     .replace(/<h1[^>]*>(.*?)<\/h1>/gi, "# $1\n")
     .replace(/<h2[^>]*>(.*?)<\/h2>/gi, "## $1\n")
@@ -162,12 +162,33 @@ function htmlToMarkdown(html: string): string {
     .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
     .replace(/<p[^>]*>/gi, "")
     .replace(/<\/p>/gi, "\n")
-    .replace(/<br\s*\/?>/gi, "\n")
-    // Remove remaining HTML tags
+    .replace(/<br\s*\/?>/gi, "\n");
+
+  // Remove remaining HTML tags (potential incomplete multi-character sanitization) repeatedly
+  let previous;
+  do {
+    previous = markdown;
+    markdown = markdown.replace(/<[^>]+>/g, "");
+  } while (markdown !== previous);
+
+  // Clean up extra whitespace
+  markdown = markdown
+    (function removeAllHtmlTags(input) {
+      let prev;
+      do {
+        prev = input;
+        input = input.replace(/<[^>]+>/g, "");
+      } while (prev !== input);
+      return input;
+    })(/* value from previous chain */)
+    // Apply repeated removal to cover incomplete multi-character sanitization
+    .replace(/<[^>]+>/g, "")
     .replace(/<[^>]+>/g, "")
     // Clean up extra whitespace
     .replace(/\n{3,}/g, "\n\n")
     .trim();
+  return markdown;
+}
 }
 
 // Rich text editor inner component (loaded only on client)


### PR DESCRIPTION
Potential fix for [https://github.com/Taskosaur/Taskosaur/security/code-scanning/81](https://github.com/Taskosaur/Taskosaur/security/code-scanning/81)

To fix this problem, we must ensure that all HTML tags (i.e. any substring matching `<...>`) are thoroughly removed from the string. The simplest strategy is to apply the tag-removal regex *repeatedly* until no further replacements are made. This approach closes the "gap" that can occur with simple `.replace` calls, covering cases where a single pass does not catch all maliciously crafted input. 

Specifically, in `htmlToMarkdown`, replace the single `.replace(/<[^>]+>/g, "")` line with a loop:
- Before the chain ends (at line 170 or so), apply the regex repeatedly in a loop until no further changes occur.
- You can isolate the HTML tag-stripping step right before other whitespace clean-ups (after the standard replacements).
- No changes to imports or other utilities are needed, as this is just a small logic addition in the function body of `htmlToMarkdown`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
