### PR TITLE
Fix OpenAI completion params for GPT-5

### DIFF
--- a/backend/src/modules/ai-chat/ai-chat.service.ts
+++ b/backend/src/modules/ai-chat/ai-chat.service.ts
@@ -151,6 +151,8 @@ CRITICAL RULES:
         content: userMessage,
       });
 
+      const isGpt5Model = typeof model === 'string' && model.startsWith('gpt-5');
+
       // Prepare request based on provider
       let requestUrl = apiUrl;
       const requestHeaders: any = {
@@ -180,9 +182,13 @@ CRITICAL RULES:
           requestUrl = `${apiUrl}/chat/completions`;
           delete requestBody.max_tokens;
           requestBody.max_completion_tokens = 500;
-          requestBody.top_p = 0.9;
-          requestBody.frequency_penalty = 0;
-          requestBody.presence_penalty = 0;
+          if (isGpt5Model) {
+            delete requestBody.temperature;
+          } else {
+            requestBody.top_p = 0.9;
+            requestBody.frequency_penalty = 0;
+            requestBody.presence_penalty = 0;
+          }
           break;
 
         case 'ollama':
@@ -411,6 +417,8 @@ CRITICAL RULES:
         },
       ];
 
+      const isGpt5Model = typeof model === 'string' && model.startsWith('gpt-5');
+
       // Prepare request based on provider
       let requestUrl = validatedUrl;
       const requestHeaders: any = {
@@ -437,6 +445,9 @@ CRITICAL RULES:
           requestUrl = `${validatedUrl}/chat/completions`;
           delete requestBody.max_tokens;
           requestBody.max_completion_tokens = 50;
+          if (isGpt5Model) {
+            delete requestBody.temperature;
+          }
           break;
 
         case 'ollama':


### PR DESCRIPTION
## Summary
- use `max_completion_tokens` for OpenAI chat requests
- skip `temperature` for GPT-5 models

## Testing
- not run (not requested)