### PR TITLE
fix(auth): forward iss param in OIDC callback for RFC 9207 compliance

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -421,6 +421,7 @@ export class AuthController {
   async oidcCallback(
     @Query('code') code: string,
     @Query('state') state: string,
+    @Query('iss') iss: string,
     @Req() req: Request,
     @Res() res: Response,
   ) {
@@ -437,6 +438,7 @@ export class AuthController {
         state,
         storedState,
         storedNonce,
+        iss,
       );
 
       // Clear OIDC cookies

--- a/backend/src/modules/auth/services/oidc.service.spec.ts
+++ b/backend/src/modules/auth/services/oidc.service.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { SettingsService } from '../../settings/settings.service';
+import { OidcService } from './oidc.service';
+
+describe('OidcService', () => {
+  let service: OidcService;
+  let oidcClientCallback: jest.Mock;
+
+  const baseConfig = {
+    enabled: true,
+    providerName: 'Test SSO',
+    issuerUrl: 'https://issuer.example.com',
+    clientId: 'test-client',
+    clientSecret: 'test-secret',
+    redirectUri: 'https://app.example.com/api/auth/oidc/callback',
+  };
+
+  const mockUser = {
+    id: 'user-id',
+    email: 'alice@example.com',
+    firstName: 'Alice',
+    lastName: 'Smith',
+    role: 'MEMBER',
+    username: 'alice',
+    avatar: null,
+    status: 'ACTIVE',
+    refreshToken: null,
+  };
+
+  const prismaMock = {
+    user: {
+      update: jest.fn().mockResolvedValue(mockUser),
+    },
+  };
+
+  const settingsMock = {
+    get: jest.fn(),
+  };
+
+  const jwtMock = {
+    sign: jest.fn().mockReturnValue('signed-token'),
+  };
+
+  const configMock = {
+    get: jest.fn((_key: string, fallback?: unknown) => fallback ?? 'test-value'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OidcService,
+        { provide: PrismaService, useValue: prismaMock },
+        { provide: SettingsService, useValue: settingsMock },
+        { provide: JwtService, useValue: jwtMock },
+        { provide: ConfigService, useValue: configMock },
+      ],
+    }).compile();
+
+    service = module.get<OidcService>(OidcService);
+
+    oidcClientCallback = jest.fn().mockResolvedValue({
+      claims: () => ({
+        email: mockUser.email,
+        email_verified: true,
+        given_name: mockUser.firstName,
+        family_name: mockUser.lastName,
+        sub: 'external-id-123',
+      }),
+    });
+
+    jest.spyOn(service as any, 'getClient').mockResolvedValue({
+      callback: oidcClientCallback,
+    });
+
+    jest.spyOn(service, 'getOidcConfig').mockResolvedValue(baseConfig);
+
+    jest.spyOn(service as any, 'findOrCreateSsoUser').mockResolvedValue(mockUser);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('handleCallback iss parameter forwarding (RFC 9207)', () => {
+    it('forwards iss to openid-client when provided', async () => {
+      await service.handleCallback(
+        'auth-code',
+        'state-123',
+        'state-123',
+        'nonce-xyz',
+        'https://issuer.example.com',
+      );
+
+      expect(oidcClientCallback).toHaveBeenCalledTimes(1);
+      const [, params] = oidcClientCallback.mock.calls[0];
+      expect(params).toEqual({
+        code: 'auth-code',
+        state: 'state-123',
+        iss: 'https://issuer.example.com',
+      });
+    });
+
+    it('omits iss when not provided (backwards compatible)', async () => {
+      await service.handleCallback('auth-code', 'state-123', 'state-123', 'nonce-xyz');
+
+      expect(oidcClientCallback).toHaveBeenCalledTimes(1);
+      const [, params] = oidcClientCallback.mock.calls[0];
+      expect(params).toEqual({ code: 'auth-code', state: 'state-123' });
+      expect(params).not.toHaveProperty('iss');
+    });
+
+    it('omits iss when passed as empty string', async () => {
+      await service.handleCallback('auth-code', 'state-123', 'state-123', 'nonce-xyz', '');
+
+      expect(oidcClientCallback).toHaveBeenCalledTimes(1);
+      const [, params] = oidcClientCallback.mock.calls[0];
+      expect(params).not.toHaveProperty('iss');
+    });
+  });
+});

--- a/backend/src/modules/auth/services/oidc.service.ts
+++ b/backend/src/modules/auth/services/oidc.service.ts
@@ -137,7 +137,13 @@ export class OidcService {
     return { url, state, nonce };
   }
 
-  async handleCallback(code: string, state: string, storedState: string, storedNonce: string) {
+  async handleCallback(
+    code: string,
+    state: string,
+    storedState: string,
+    storedNonce: string,
+    iss?: string,
+  ) {
     if (state !== storedState) {
       throw new BadRequestException('Invalid SSO state parameter');
     }
@@ -145,14 +151,23 @@ export class OidcService {
     const oidcClient = await this.getClient();
     const config = await this.getOidcConfig();
 
+    // RFC 9207 requires the `iss` authorization response parameter to be
+    // forwarded to the client so openid-client can verify it matches the
+    // issuer advertised in the discovery document. Providers like Keycloak
+    // advertise `authorization_response_iss_parameter_supported: true` and
+    // will fail token exchange if `iss` is omitted from the params.
+    const callbackParams: { code: string; state: string; iss?: string } = { code, state };
+    if (iss) {
+      callbackParams.iss = iss;
+    }
+
     let tokenSet: { claims: () => Record<string, unknown> };
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      tokenSet = await oidcClient.callback(
-        config.redirectUri,
-        { code, state },
-        { state: storedState, nonce: storedNonce },
-      );
+      tokenSet = await oidcClient.callback(config.redirectUri, callbackParams, {
+        state: storedState,
+        nonce: storedNonce,
+      });
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`OIDC callback error: ${msg}`);


### PR DESCRIPTION
## Description

OIDC SSO login fails with `SSO Authentication Failed` for all users whose identity provider advertises `authorization_response_iss_parameter_supported: true` in its discovery document (Keycloak 19+ by default, and other OPs following RFC 9207).

The backend logs show the real error:

```
ERROR [OidcService] OIDC callback error: iss missing from the response
```

`openid-client` v5 enforces RFC 9207: when the issuer's discovery metadata declares `authorization_response_iss_parameter_supported: true`, the library validates that `iss` is present in the parameters passed to `client.callback()`. The callback controller in `auth.controller.ts` only reads `code` and `state` from the query string, so `iss` is dropped even though the IdP sends it in the redirect. Every fresh SSO login fails.

This PR threads the `iss` authorization-response parameter from the callback query string through `AuthController.oidcCallback` into `OidcService.handleCallback`, and includes it in the params object passed to `oidcClient.callback()` when present.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Reproduction

1. Configure SSO against a Keycloak realm (19+) where `authorization_response_iss_parameter_supported` is `true` (the default).
2. Log out, click the SSO login button.
3. Keycloak redirects back with `?code=...&state=...&iss=https://...` but Taskosaur responds with `SSO Authentication Failed`.
4. Server logs show `OIDC callback error: iss missing from the response`.

After this fix, the same flow completes successfully.

## Changes

- `backend/src/modules/auth/auth.controller.ts` — add `@Query('iss') iss: string` and pass it into `handleCallback`.
- `backend/src/modules/auth/services/oidc.service.ts` — accept optional `iss`, build the params object conditionally so it is included only when the IdP sends it (backwards compatible with IdPs that don't advertise RFC 9207 support).
- `backend/src/modules/auth/services/oidc.service.spec.ts` — new unit tests covering:
  - `iss` is forwarded to `openid-client` when provided
  - `iss` is omitted when not provided (backwards compatible)
  - `iss` is omitted when passed as an empty string

## Testing

- [x] Code builds successfully (`npm run build`)
- [x] New unit tests pass (`npx jest src/modules/auth/services/oidc.service.spec.ts` — 3/3 passing)
- [x] No console errors or warnings introduced; formatting and lint verified on touched files
- [x] Manually verified end-to-end against Keycloak 26 — SSO login now completes instead of returning "SSO Authentication Failed"

## Checklist
- [x] Code follows style guidelines (prettier + eslint clean on touched files)
- [x] Self-review completed
- [x] Documentation updated (not applicable — internal bug fix, no public API change beyond an additive optional parameter)
- [x] No breaking changes — `iss` is optional, existing IdPs that don't advertise `authorization_response_iss_parameter_supported` continue to work unchanged

## References

- RFC 9207 — OAuth 2.0 Authorization Server Issuer Identification: https://www.rfc-editor.org/rfc/rfc9207
- openid-client enforcement: https://github.com/panva/node-openid-client (v5.x validates `iss` when the issuer advertises support)