### PR TITLE
feat(ai-chat): add Anthropic prompt caching for Claude-family models

### DIFF
--- a/backend/src/modules/ai-chat/ai-chat.service.spec.ts
+++ b/backend/src/modules/ai-chat/ai-chat.service.spec.ts
@@ -1,0 +1,226 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiChatService } from './ai-chat.service';
+import { SettingsService } from '../settings/settings.service';
+
+describe('AiChatService', () => {
+  let service: AiChatService;
+  let fetchMock: jest.SpyInstance;
+
+  const settingsMock = {
+    get: jest.fn(),
+  };
+
+  const settingsFor = (
+    overrides: Partial<{
+      enabled: string;
+      apiKey: string;
+      model: string;
+      apiUrl: string;
+    }> = {},
+  ) => {
+    const { enabled = 'true', apiKey = 'sk-test', model, apiUrl } = overrides;
+    return (key: string, _userId: string, fallback?: string) => {
+      switch (key) {
+        case 'ai_enabled':
+          return enabled;
+        case 'ai_api_key':
+          return apiKey;
+        case 'ai_model':
+          return model ?? fallback;
+        case 'ai_api_url':
+          return apiUrl ?? fallback;
+        default:
+          return fallback;
+      }
+    };
+  };
+
+  const okJsonResponse = (body: unknown) =>
+    ({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    }) as unknown as Response;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AiChatService, { provide: SettingsService, useValue: settingsMock }],
+    }).compile();
+
+    service = module.get<AiChatService>(AiChatService);
+    settingsMock.get.mockReset();
+    fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okJsonResponse({
+        choices: [{ message: { content: 'ok' } }],
+        content: [{ text: 'ok' }],
+        candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
+  const getSentBody = () => {
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    return JSON.parse(init.body as string);
+  };
+
+  describe('getModelFamily', () => {
+    const cases: Array<[string, 'anthropic' | 'openai' | 'google' | 'unknown']> = [
+      ['claude-sonnet-4-5', 'anthropic'],
+      ['anthropic/claude-3.5-sonnet', 'anthropic'],
+      ['my-proxy/claude-opus-4', 'anthropic'],
+      ['gpt-4o-mini', 'openai'],
+      ['openai/gpt-5', 'openai'],
+      ['o3-mini', 'openai'],
+      ['chatgpt-4o-latest', 'openai'],
+      ['gemini-2.0-flash', 'google'],
+      ['google/gemini-2.5-pro', 'google'],
+      ['deepseek/deepseek-chat-v3-0324:free', 'unknown'],
+      ['mistral-large', 'unknown'],
+    ];
+
+    it.each(cases)('classifies %s as %s', (model, expected) => {
+      expect((service as any).getModelFamily(model)).toBe(expected);
+    });
+
+    it('returns unknown for non-string input', () => {
+      expect((service as any).getModelFamily(undefined)).toBe('unknown');
+      expect((service as any).getModelFamily(null)).toBe('unknown');
+      expect((service as any).getModelFamily(42)).toBe('unknown');
+    });
+  });
+
+  describe('chat() — prompt caching', () => {
+    it('attaches cache_control on the Anthropic-native system block', async () => {
+      settingsMock.get.mockImplementation(
+        settingsFor({
+          model: 'claude-sonnet-4-5',
+          apiUrl: 'https://api.anthropic.com/v1',
+        }),
+      );
+
+      await service.chat({ message: 'hi' }, 'user-1');
+
+      const body = getSentBody();
+      expect(Array.isArray(body.system)).toBe(true);
+      expect(body.system[0]).toMatchObject({
+        type: 'text',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(typeof body.system[0].text).toBe('string');
+      expect(body.system[0].text.length).toBeGreaterThan(0);
+    });
+
+    it('rewrites system message for OpenRouter + Claude with cache_control', async () => {
+      settingsMock.get.mockImplementation(
+        settingsFor({
+          model: 'anthropic/claude-3.5-sonnet',
+          apiUrl: 'https://openrouter.ai/api/v1',
+        }),
+      );
+
+      await service.chat({ message: 'hi' }, 'user-1');
+
+      const body = getSentBody();
+      const systemMsg = body.messages.find((m: { role: string }) => m.role === 'system');
+      expect(systemMsg).toBeDefined();
+      expect(Array.isArray(systemMsg.content)).toBe(true);
+      expect(systemMsg.content[0]).toMatchObject({
+        type: 'text',
+        cache_control: { type: 'ephemeral' },
+      });
+    });
+
+    it('rewrites system message for a custom proxy hosting Claude', async () => {
+      settingsMock.get.mockImplementation(
+        settingsFor({
+          model: 'claude-opus-4-7',
+          apiUrl: 'https://proxy.example.com/v1',
+        }),
+      );
+
+      await service.chat({ message: 'hi' }, 'user-1');
+
+      const body = getSentBody();
+      const systemMsg = body.messages.find((m: { role: string }) => m.role === 'system');
+      expect(systemMsg.content[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+
+    it('does NOT add cache_control for OpenAI direct with a GPT model', async () => {
+      settingsMock.get.mockImplementation(
+        settingsFor({
+          model: 'gpt-4o-mini',
+          apiUrl: 'https://api.openai.com/v1',
+        }),
+      );
+
+      await service.chat({ message: 'hi' }, 'user-1');
+
+      const body = getSentBody();
+      const systemMsg = body.messages.find((m: { role: string }) => m.role === 'system');
+      expect(typeof systemMsg.content).toBe('string');
+      expect(JSON.stringify(body)).not.toContain('cache_control');
+    });
+
+    it('does NOT add cache_control for OpenRouter + GPT model', async () => {
+      settingsMock.get.mockImplementation(
+        settingsFor({
+          model: 'openai/gpt-4o-mini',
+          apiUrl: 'https://openrouter.ai/api/v1',
+        }),
+      );
+
+      await service.chat({ message: 'hi' }, 'user-1');
+
+      const body = getSentBody();
+      expect(JSON.stringify(body)).not.toContain('cache_control');
+    });
+
+    it('does NOT add cache_control for Google Gemini native wire', async () => {
+      settingsMock.get.mockImplementation(
+        settingsFor({
+          model: 'gemini-2.0-flash',
+          apiUrl: 'https://generativelanguage.googleapis.com/v1beta',
+        }),
+      );
+
+      await service.chat({ message: 'hi' }, 'user-1');
+
+      const body = getSentBody();
+      expect(JSON.stringify(body)).not.toContain('cache_control');
+      expect(body.contents).toBeDefined();
+    });
+
+    it('does NOT add cache_control for Ollama + non-Claude model', async () => {
+      settingsMock.get.mockImplementation(
+        settingsFor({
+          apiKey: '',
+          model: 'llama3',
+          apiUrl: 'http://localhost:11434/v1',
+        }),
+      );
+
+      await service.chat({ message: 'hi' }, 'user-1');
+
+      const body = getSentBody();
+      expect(JSON.stringify(body)).not.toContain('cache_control');
+    });
+
+    it('does NOT add cache_control for an unknown-family model on a custom proxy', async () => {
+      settingsMock.get.mockImplementation(
+        settingsFor({
+          model: 'deepseek/deepseek-chat-v3-0324:free',
+          apiUrl: 'https://openrouter.ai/api/v1',
+        }),
+      );
+
+      await service.chat({ message: 'hi' }, 'user-1');
+
+      const body = getSentBody();
+      expect(JSON.stringify(body)).not.toContain('cache_control');
+    });
+  });
+});

--- a/backend/src/modules/ai-chat/ai-chat.service.ts
+++ b/backend/src/modules/ai-chat/ai-chat.service.ts
@@ -16,6 +16,53 @@ import { getAutomationPrompt } from './automation-prompts';
 export class AiChatService {
   constructor(private settingsService: SettingsService) {}
 
+  /**
+   * Detect the API vendor/family from the model string so we can apply
+   * vendor-specific features (currently prompt caching) even when the
+   * `provider` is `custom` (e.g. CLIProxyAPI, LiteLLM) and the URL gives
+   * no hint about the backing model.
+   *
+   * Matches:
+   *  - anthropic: `claude-*`, `anthropic/*`, `.../claude-*`
+   *  - openai:   `gpt-*`, `o1-*`, `o3-*`, `o4-*`, `chatgpt*`, and the same with an org prefix
+   *  - google:   `gemini-*`, `google/gemini-*`
+   */
+  private getModelFamily(model: unknown): 'anthropic' | 'openai' | 'google' | 'unknown' {
+    if (typeof model !== 'string') return 'unknown';
+    const m = model.toLowerCase();
+    if (/(^|\/)claude[-/]/.test(m) || m.includes('anthropic')) return 'anthropic';
+    if (/(^|\/)(gpt-|o1-|o3-|o4-|chatgpt)/.test(m)) return 'openai';
+    if (/(^|\/)gemini[-/]/.test(m)) return 'google';
+    return 'unknown';
+  }
+
+  /**
+   * Attach an Anthropic prompt-cache breakpoint to the system message for
+   * OpenAI-wire requests that route to a Claude model (OpenRouter, custom
+   * proxies backing Anthropic). The OpenAI-compatible shape uses a content
+   * array on the system message with `cache_control` on the text block;
+   * proxies that do not recognize the field silently drop it.
+   *
+   * Only call this when the model family is `anthropic` — sending
+   * `cache_control` to OpenAI directly can trigger strict-schema 400s.
+   */
+  private withAnthropicCacheBreakpoint(messages: ChatMessageDto[]): unknown[] {
+    return messages.map((m) =>
+      m.role === 'system'
+        ? {
+            role: 'system',
+            content: [
+              {
+                type: 'text',
+                text: m.content,
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          }
+        : m,
+    );
+  }
+
   private detectProvider(apiUrl: string): string {
     try {
       const parsedUrl = new URL(apiUrl);
@@ -247,6 +294,7 @@ FILTER RULES (VERY IMPORTANT - for filtering tasks by priority, status, type, et
       });
 
       const isGpt5Model = typeof model === 'string' && model.startsWith('gpt-5');
+      const modelFamily = this.getModelFamily(model);
 
       // Prepare request based on provider
       let requestUrl = apiUrl;
@@ -304,19 +352,29 @@ FILTER RULES (VERY IMPORTANT - for filtering tasks by priority, status, type, et
           requestBody.top_p = 0.9;
           break;
 
-        case 'anthropic':
+        case 'anthropic': {
           requestUrl = `${apiUrl}/messages`;
           requestHeaders['x-api-key'] = apiKey;
           requestHeaders['anthropic-version'] = '2023-06-01';
           delete requestHeaders['Authorization'];
+          const systemContent = messages.find((m) => m.role === 'system')?.content ?? '';
           requestBody = {
             model,
             messages: messages.filter((m) => m.role !== 'system'), // Anthropic doesn't use system role the same way
-            system: messages.find((m) => m.role === 'system')?.content,
+            // Array form with `cache_control` enables prompt caching on the
+            // (large, stable) system prompt. Paid on first write, ~0.1x on reads.
+            system: [
+              {
+                type: 'text',
+                text: systemContent,
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
             max_tokens: 500,
             temperature: 0.1,
           };
           break;
+        }
 
         case 'google':
           // Google Gemini has a different API structure
@@ -338,6 +396,17 @@ FILTER RULES (VERY IMPORTANT - for filtering tasks by priority, status, type, et
         default: // custom or openrouter fallback
           requestUrl = `${apiUrl}/chat/completions`;
           break;
+      }
+
+      // Enable Anthropic prompt caching when a Claude model is served over an
+      // OpenAI-compatible wire (OpenRouter, custom proxies like CLIProxyAPI,
+      // self-hosted Ollama fronting Claude). The Anthropic-native branch above
+      // already attaches `cache_control` directly on the system block.
+      if (
+        modelFamily === 'anthropic' &&
+        (provider === 'openrouter' || provider === 'ollama' || provider === 'custom')
+      ) {
+        requestBody.messages = this.withAnthropicCacheBreakpoint(messages);
       }
 
       // Call API


### PR DESCRIPTION
## Description

Enables Anthropic prompt caching for the AI chat module. Caches the large, stable system prompt (~130 lines / several thousand tokens) sent on every browser-automation request. Cache reads cost ~0.1x base input and cache writes cost ~1.25x — break-even after two requests inside the 5-minute ephemeral TTL.

Detection is **model-family based**, not URL-based, so caching activates on custom proxies (CLIProxyAPI, LiteLLM, self-hosted OpenRouter-style gateways) where `detectProvider()` resolves to `custom`.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Behavior matrix

| Wire format | Model family | Action |
|---|---|---|
| Anthropic native (`api.anthropic.com`) | Claude | `system` wrapped as array with `cache_control: { type: "ephemeral" }` |
| OpenAI-compatible (openrouter, custom, ollama) | Claude | system message rewritten to content-array form with `cache_control` on the text block |
| OpenAI direct (`api.openai.com`) | GPT | untouched — OpenAI auto-caches prefixes >=1024 tokens |
| Google Gemini native | Gemini | untouched — has no inline cache knob |
| Any wire | Unknown/non-Claude | untouched |

`generateDescription()` and `testConnection()` are intentionally skipped — their system prompts are below Anthropic's 1024-token minimum cacheable prefix, so `cache_control` would be a silent no-op there.

## Changes

- `backend/src/modules/ai-chat/ai-chat.service.ts`
  - `getModelFamily(model)` — classifies model string as `anthropic` / `openai` / `google` / `unknown`. Handles plain (`claude-sonnet-4-5`), org-prefixed (`anthropic/claude-3.5-sonnet`), and nested-proxy (`my-proxy/claude-opus-4`) forms.
  - `withAnthropicCacheBreakpoint(messages)` — rewrites the system message into OpenAI-wire content-array form with `cache_control`.
  - `chat()` Anthropic-native branch: `system` now an array with `cache_control` breakpoint.
  - `chat()` post-switch guard applies the OpenAI-wire rewrite when `family === 'anthropic'` and provider is in {openrouter, ollama, custom}.
- `backend/src/modules/ai-chat/ai-chat.service.spec.ts` — new unit-test suite (20 tests) covering model-family classification and the presence/absence of `cache_control` across all provider x model-family combinations.

## Testing

- [x] `npx jest src/modules/ai-chat/ai-chat.service.spec.ts` — 20/20 pass
- [x] `npx eslint src/modules/ai-chat/ai-chat.service.ts` — clean
- [x] `npx tsc --noEmit -p tsconfig.json` — no new errors introduced (pre-existing 7 errors in `src/modules/queue/*` tests are unchanged, verified by diffing with and without the patch)
- [x] Manual review: cache takes effect only when the backing model is Claude, so `cache_control` is never sent to OpenAI/Gemini/Ollama backends where it could trigger a strict-schema 400

## Verification after merge

Response `usage` should include either (a) `cache_read_input_tokens` / `cache_creation_input_tokens` on Anthropic native or (b) equivalent OpenRouter usage fields for Claude-via-OpenRouter. If both are zero across repeated requests with identical prefixes, the system prompt may be below the 1024-token minimum cacheable prefix or a silent invalidator (timestamp/UUID in the prompt) is at work.

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Unit tests added for new behavior
- [x] No breaking changes